### PR TITLE
Fix path handling in recursive fetch

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,10 +16,14 @@ def process_path(path: str):
         results = [os.path.basename(path), "bad_formatting"]
     return results
 
-def fetch_object(object: str):
-    if os.path.isdir(object):
-        paths = os.listdir(object)
-        for item in paths:
-            fetch_object(item)
+def fetch_object(path: str):
+    """Recursively process ``path`` and return a list of processed results."""
+
+    results = []
+    if os.path.isdir(path):
+        for item in os.listdir(path):
+            item_path = os.path.join(path, item)
+            results.extend(fetch_object(item_path))
     else:
-        process_path(object)
+        results.append(process_path(path))
+    return results

--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ from app.file_observers import FSEHandler
 import time
 
 if __name__ == "__main__":
-    fetch_object(CURRENT_DIRECTORY)
+    results = fetch_object(CURRENT_DIRECTORY)
+    print(results)
     observer = Observer()
     handler = FSEHandler()
     observer.schedule(handler, path=CURRENT_DIRECTORY, recursive=True)

--- a/tests/test_fetch_object.py
+++ b/tests/test_fetch_object.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import fetch_object
+from app.config import CURRENT_DIRECTORY
+
+
+def test_fetch_object_returns_expected_results():
+    results = fetch_object(CURRENT_DIRECTORY)
+    assert ['vizitka.cdr', './example/test_archive/Saqo/vizitkeq/karmir/vizitka.cdr'] in results
+    assert ['new.txt', 'bad_formatting'] in results
+    assert ['iore.tio', 'bad_formatting'] in results


### PR DESCRIPTION
## Summary
- fix recursion path handling in `fetch_object`
- return results from recursion and print them in `main.py`
- add regression test for `fetch_object`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684547d079cc83268e39cd1256a889d1