### PR TITLE
Add basic PySide6 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Chroma Tree
 
 программа для управления и архивирования дизайн файлов
+
+## GUI
+
+Install dependencies and start the graphical interface:
+
+```bash
+pip install -r requirements.txt  # or use the dependencies in `pyproject.toml`
+python -m app.gui
+```

--- a/app/gui.py
+++ b/app/gui.py
@@ -1,0 +1,40 @@
+from PySide6.QtWidgets import QApplication, QMainWindow, QPushButton, QTextEdit, QVBoxLayout, QWidget
+from PySide6.QtCore import Slot
+
+from . import fetch_object
+from .config import CURRENT_DIRECTORY
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Chroma Tree")
+
+        self.text_area = QTextEdit()
+        self.text_area.setReadOnly(True)
+
+        button = QPushButton("Process Directory")
+        button.clicked.connect(self.process_directory)
+
+        layout = QVBoxLayout()
+        layout.addWidget(button)
+        layout.addWidget(self.text_area)
+
+        container = QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+    @Slot()
+    def process_directory(self):
+        results = fetch_object(CURRENT_DIRECTORY)
+        display = "\n".join(f"{r[0]} -> {r[1]}" for r in results)
+        self.text_area.setPlainText(display)
+
+
+def run():
+    app = QApplication([])
+    window = MainWindow()
+    window.show()
+    app.exec()
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "watchdog>=6.0.0",
+    "PySide6>=6.9",
 ]


### PR DESCRIPTION
## Summary
- add PySide6 GUI with a simple main window
- document how to run the GUI
- include PySide6 in project dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684548e607588326bacbe91239a949b1